### PR TITLE
Feature/login: 로그인 api 연동 및 로그인 상태 관리 커스텀 훅 추가

### DIFF
--- a/Temp.md
+++ b/Temp.md
@@ -393,3 +393,6 @@ instance.interceptors.request.use(function () {
   </li>
 
 ```
+
+## 레퍼런스
+- zustand 미들웨어 영속성:  https://zustand.docs.pmnd.rs/middlewares/persist#persisting-a-state

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,14 +1,11 @@
 import { AxiosError } from "axios"
 import { apiRoutes } from "../config/api"
 import instance from "../config/axios"
-import { Email, RegisterRequest } from "../types/auth.types"
+import { Email, LoginRequest, RegisterRequest } from "../types/auth.types"
 import { toast } from "react-toastify"
 
 
-// 로그인 요청
-export const login = () => { }
-
-// 회원가입 요청
+/** 회원가입 요청*/
 export const registerFetch = async (registerRequest: RegisterRequest) => {
 
     const body = {
@@ -32,14 +29,12 @@ export const registerFetch = async (registerRequest: RegisterRequest) => {
 
         }
     }
-
 }
 
-// 이메일 중복 확인
+/** 이메일 중복 확인 */
 export const emailCheckFetch = async (email: Email) => {
 
     const body = JSON.stringify(email)
-
 
     try {
         await instance.post(apiRoutes.auth.checkEmail, body);
@@ -55,6 +50,65 @@ export const emailCheckFetch = async (email: Email) => {
         if (error instanceof Error) {
             alert("500: 네트워크 문제로 요청에 실패하였습니다.")
             return false
+        }
+    }
+}
+
+
+/** 로그인 요청 */
+export const loginFetch = async (loginRequest: LoginRequest) => {
+    const body = {
+        email: loginRequest.email,
+        password: loginRequest.password
+    }
+
+    try {
+        const response = await instance.post(
+            apiRoutes.auth.login,
+            JSON.stringify(body)
+        )
+
+        if (response?.status && response.status > 399) {
+            toast.error(response.status + ": 로그인에 실패하였습니다.")
+            throw new AxiosError("로그인에 실패하였습니다.", response.data.StatusCode || "UNKNOWN_ERROR")
+        }
+
+        return response
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            toast.error("에러: " + error.response?.data.message)
+            return error.response
+
+        } else {
+            toast.error("500: 네트워크 문제로 요청에 실패하였습니다.")
+
+
+        }
+    }
+}
+
+
+/** 유저 프로필 정보 요청*/
+export const getProfileFetch = async () => {
+    try {
+        const response = await instance.get(
+            apiRoutes.user.profile,
+        )
+
+        if (response?.status && response.status > 399) {
+            toast.error(response.status + ": 프로필 조회에 실패하였습니다.")
+            throw new AxiosError("프로필 조회에 실패하였습니다.", response.data.StatusCode || "UNKNOWN_ERROR")
+        }
+
+        return response.data
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            toast.error("에러: " + error.response?.data.message)
+            return error.response?.data
+
+        } else {
+            toast.error("500: 네트워크 문제로 요청에 실패하였습니다.")
+
         }
     }
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react";
 import { IoSearchOutline } from "react-icons/io5";
 import { Link } from "react-router";
+import useAuth from "../../hooks/useAuth";
 
 export default function Header() {
+
+    const isLogin = useAuth();
 
     return (
         <header className="p-4 bg-white flex justify-between">
@@ -20,20 +24,27 @@ export default function Header() {
                     <IoSearchOutline size={24} />
                 </button>
                 <ul className="flex mr-2.5">
-                    <li title="로그인" className="mx-2 border p-1 px-2 border-[#e6e7e9] rounded-2xl w-[88px] text-center">
-                        <Link to={"/auth/login"}>
-                            <span>
-                                로그인
-                            </span>
-                        </Link>
-                    </li>
-                    <li title="회원가입" className="mx-2  p-1 px-2 rounded-2xl w-[88px] text-center bg-[#05d182] text-white">
-                        <Link to={"/auth/signup"}>
-                            <span>
-                                회원가입
-                            </span>
-                        </Link>
-                    </li>
+                    {
+                        isLogin
+                            ? <li>로그인됨</li>
+                            : <>
+                                <li title="로그인" className="mx-2 border p-1 px-2 border-[#e6e7e9] rounded-2xl w-[88px] text-center">
+                                    <Link to={"/auth/login"}>
+                                        <span>
+                                            로그인
+                                        </span>
+                                    </Link>
+                                </li>
+                                <li title="회원가입" className="mx-2  p-1 px-2 rounded-2xl w-[88px] text-center bg-[#05d182] text-white">
+                                    <Link to={"/auth/signup"}>
+                                        <span>
+                                            회원가입
+                                        </span>
+                                    </Link>
+                                </li>
+                            </>
+                    }
+
                 </ul>
             </div>
         </header>

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -10,8 +10,8 @@ export const apiRoutes = {
         logout: baseUrl + '/users/logout',
         register: baseUrl + '/users/register',
         checkEmail: baseUrl + '/users/register/duplicate-check',
-        sendVerificationCode: baseUrl +'/users/send-verification-code',
-        checkVerificationCode: baseUrl +'/users/send-verification'
+        sendVerificationCode: baseUrl + '/users/send-verification-code',
+        checkVerificationCode: baseUrl + '/users/send-verification'
     },
     user: {
         profile: baseUrl + '/users/me',

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -4,10 +4,11 @@ import { getToken } from "../utils/storage";
 
 // axios 인스턴스를 만들 때 구성 기본 값 설정
 const instance = axios.create({
-    baseURL: baseUrl,
-    headers: {
-        "Content-Type": "application/json",
-      },
+  baseURL: baseUrl,
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true
 });
 
 // 인스턴스가 생성 된 후 기본값 변경

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+import { getToken } from '../utils/storage'
+
+export default function useAuth() {
+
+        const [isLogin, setIsLogin] = useState(false)
+        useEffect(() => {
+                const localToken = getToken();
+                if (localToken) return setIsLogin(true)
+                setIsLogin(false)
+        }, [])
+
+        return isLogin;
+}

--- a/src/hooks/useRedirection.tsx
+++ b/src/hooks/useRedirection.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { getToken } from "../utils/storage";
+import { useNavigate } from "react-router";
+import { toast } from "react-toastify";
+
+
+export default function useAuth() {
+    const router = useNavigate();
+
+    useEffect(() => {
+        const token = getToken();
+
+        // 비로그인 상태라면 로그인 페이지로
+        if (!token) {
+            toast.info("로그인 후 이용해주세요.")
+            router("/auth/login")
+        }
+
+        // 로그인 상태라면 루트  페이지로
+        if (token) {
+            router("/")
+        }
+    }, [])
+}

--- a/src/pages/Login/components/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm.tsx
@@ -1,15 +1,55 @@
-import { useState } from "react"
-import { Link } from "react-router"
+import { FormEvent } from "react"
+import { Link, useNavigate } from "react-router"
 import { HiOutlineMail } from "react-icons/hi";
 import { IoLockOpenOutline } from "react-icons/io5";
+import { toast } from "react-toastify";
+import { getInitialProfile, login } from "../../../service/auth";
+import Submit from "../../Register/components/Submit";
+import { useUserStore } from "../../../store/loginState";
+import useAuth from "../../../hooks/useRedirection";
 
 
 export default function LoginForm() {
+    useAuth();
 
-    const [loginErrors, setLoginErrors] = useState({
-        email: '',
-        password: ''
-    })
+    const router = useNavigate();
+
+    const { setUserState } = useUserStore()
+
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+
+        e.preventDefault();
+
+        const formData = new FormData(e.currentTarget);
+
+        const email = formData.get('email')?.toString() || ''
+        const password = formData.get('password')?.toString() || ''
+
+        if (email.length < 2) {
+            toast("이메일을 입력해주세요")
+        }
+        if (password.length < 2) {
+            toast("비밀번호를 입력해주세요")
+        }
+
+        // 로그인 요청
+        await login({ email, password })
+
+        // 프로필 조회
+        await setProfile()
+        
+        // 홈 리디렉션
+        router("/")
+
+    }
+
+    const setProfile= async() => {
+       const profile = await getInitialProfile();
+
+       setUserState(profile)
+    }
+
+
     return (
         <div className="md:h-[80vh] md:flex-row items-center flex-col-reverse h-auto flex p-[20px] max-w-[1240px] w-full bg-white rounded-3xl">
 
@@ -20,7 +60,9 @@ export default function LoginForm() {
                     <p className="mt-2">민간 약초 커뮤니티, 민초에 오신 것을 환영합니다.</p>
 
                     <div className="flex flex-col justify-center items-center mt-[1rem] w-full">
-                        <form className="mt-8 w-full max-w-[70%]">
+
+                        {/* 로그인 폼 */}
+                        <form className="mt-8 w-full max-w-[70%]" onSubmit={handleSubmit}>
                             <div className="flex items-center w-full]">
                                 <label className="w-[30px] inline-block" htmlFor="email" title="이메일"><HiOutlineMail /></label>
                                 <input className="p-2 w-full border border-[#e6e7e9] rounded-[5px]" type="email" id="email" name="email" />
@@ -29,8 +71,14 @@ export default function LoginForm() {
                                 <label className="w-[30px] inline-block" htmlFor="password" title="비밀번호"><IoLockOpenOutline /></label>
                                 <input className="p-2 w-full border border-[#e6e7e9] rounded-[5px]" type="password" id="password" name="password" />
                             </div>
-                            <button className="cursor-pointer mt-8 text-white bg-[#05D182] hover:bg-[#07BD77] max-w-[380px] w-full p-2 rounded-[5px]">로그인</button>
+                            <Submit
+                                disabled={false}
+                                text="로그인"
+                                className="cursor-pointer mt-8 text-white bg-[#05D182] hover:bg-[#07BD77] max-w-[380px] w-full p-2 rounded-[5px]"
+                            />
                         </form>
+
+                        {/* 회원가입 가이드 */}
                         <div className="mt-5 text-[14px]" >
                             <span>아직 회원이 아니신가요?</span>
                             <Link to="/auth/signup" className="ml-2 border-b hover:text-[#05D182]">회원가입</Link>

--- a/src/service/auth.ts
+++ b/src/service/auth.ts
@@ -1,5 +1,6 @@
-import { emailCheckFetch, registerFetch } from "../apis/auth";
-import { Email, RegisterRequest } from "../types/auth.types";
+import { emailCheckFetch, getProfileFetch, loginFetch, registerFetch } from "../apis/auth";
+import { Email, LoginRequest, RegisterRequest } from "../types/auth.types";
+import { setToken } from "../utils/storage";
 
 
 
@@ -7,11 +8,33 @@ import { Email, RegisterRequest } from "../types/auth.types";
  * 회원가입 요청
  * @param registerRequest 
  */
-export const register = async ( registerRequest:RegisterRequest) => {
+export const register = async (registerRequest: RegisterRequest) => {
     return await registerFetch(registerRequest)
 }
 
 
-export const emailCheck = async (email:Email)=>{
+/** 이메일 중복 체크 */
+export const emailCheck = async (email: Email) => {
     return await emailCheckFetch(email)
+}
+
+
+
+/**
+ * 로그인 요청
+ * @param loginRequest 
+ * @returns 
+ */
+export const login = async (loginRequest: LoginRequest) => {
+    const response = await loginFetch(loginRequest)
+
+    const rawToken = response?.headers['authorization'] as string
+    setToken(rawToken.split(" ")[1])
+}
+
+/** 프로필 정보 요청*/
+export const getInitialProfile = async () => {
+    const data = await getProfileFetch();
+
+    return data
 }

--- a/src/store/loginState.ts
+++ b/src/store/loginState.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { UserState } from './types/login.types'
+
+export const useUserStore = create<UserState>()(
+    persist(
+        (set) => ({
+            profile: {
+                avatarUrl: '',
+                introduction: '',
+                nickname: ''
+            },
+            setUserState: (newProfile) => set(
+                {
+                    profile: newProfile
+                })
+            //  setPosition: (position) => set({ position }),
+        }),
+        { name: 'user-state' },
+    ),
+
+)

--- a/src/store/types/login.types.ts
+++ b/src/store/types/login.types.ts
@@ -1,0 +1,73 @@
+
+
+import { Profile } from '../../types/user.types';
+
+export interface UserState {
+    profile: Profile
+    setUserState: (userState: Profile) => void
+
+}
+
+
+
+
+/**
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  // 필요한 다른 사용자 정보들
+}
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  isLoggedIn: boolean;
+  login: (user: User, token: string) => void;
+  logout: () => void;
+  updateUser: (user: Partial<User>) => void;
+}
+
+const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      token: null,
+      isLoggedIn: false,
+
+      login: (user, token) => {
+        set({ user, token, isLoggedIn: true });
+        // API 헤더에 토큰 설정
+        setAuthHeader(token);
+      },
+
+      logout: () => {
+        set({ user: null, token: null, isLoggedIn: false });
+        // API 헤더에서 토큰 제거
+        removeAuthHeader();
+        // 필요한 경우 로컬 스토리지 클리어
+        localStorage.clear();
+      },
+
+      updateUser: (updateData) => 
+        set((state) => ({
+          user: state.user ? { ...state.user, ...updateData } : null,
+        })),
+    }),
+    {
+      name: 'auth-storage', // 로컬 스토리지에 저장될 키 이름
+      partialize: (state) => ({ 
+        user: state.user,
+        token: state.token,
+        isLoggedIn: state.isLoggedIn 
+      }), // 저장할 상태 선택
+    }
+  )
+);
+
+export default useAuthStore;
+ * 
+ * 
+ * 
+ * 
+ */

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -16,3 +16,8 @@ export interface RegisterRequest {
 export type Email = {
     email: string
 }
+
+export interface LoginRequest {
+    email:string;
+    password:string;
+}

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -1,0 +1,12 @@
+
+
+export interface User {
+    email: string
+    profile: Profile
+}
+
+export interface Profile {
+    avatarUrl: string;
+    nickname: string;
+    introduction: string;
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -7,7 +7,7 @@ export const getToken = () => {
         log.warn("빈 값이 반환되었습니다.")
         return null
     }
-    return token
+    return "Bearer "+token
 }
 
 export const setToken = (value: string) => {


### PR DESCRIPTION
## 📌 PR 제목  
- 로그인 api 연동 및 로그인 상태 관리 커스텀 훅 추가

## ✨ 변경 사항  
- 로그인 api 연동  
- 커스텀 훅 추가
  - 로그인 상태 관리를 위한 커스텀 훅
  - 로그인 상태에 따른 리디렉션 커스텀 훅

## 🔍 테스트 방법  
  1. `npm install` 실행  
  2. `npm run dev` 실행 후 `POST /auth/login` API 요청 (로그인 요청)
  3. 로그인 이후 보여지는 헤더 UI 확인
  4. 로그인 이후 로그인 페이지 접속 시 리디렉션 확인 

## ❗ 주의 사항  
- 없음

## ✅ 관련 이슈  
- 없음
