### PR TITLE
Feaute/mypage 마이페이지 초기 디자인 및 레이아웃 작업, axios 인터셉터 추가

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,4 +1,3 @@
-import { toast } from "react-toastify"
 import { apiRoutes } from "../config/api"
 import instance from "../config/axios"
 import { AxiosError } from "axios"
@@ -8,7 +7,7 @@ import { getToken } from "../utils/storage"
 /** 유저 프로필 정보 요청*/
 export const getProfileFetch = async () => {
 
-    const token = getToken();
+    const token = getToken();0
     try {
         const response = await instance.get(
             apiRoutes.user.profile,
@@ -20,18 +19,15 @@ export const getProfileFetch = async () => {
         )
 
         if (response?.status && response.status > 399) {
-            toast.error(response.status + ": 프로필 조회에 실패하였습니다.")
             throw new AxiosError("프로필 조회에 실패하였습니다.", response.data.StatusCode || "UNKNOWN_ERROR")
         }
 
         return response.data
     } catch (error) {
         if (error instanceof AxiosError) {
-            toast.error("에러: " + error.response?.data.message)
             return error.response?.data
 
         } else {
-            toast.error("500: 네트워크 문제로 요청에 실패하였습니다.")
 
         }
     }

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { baseUrl } from "./api";
-import { getToken } from "../utils/storage";
+import { getToken, setToken } from "../utils/storage";
 
 // axios 인스턴스를 만들 때 구성 기본 값 설정
 const instance = axios.create({
@@ -11,7 +11,27 @@ const instance = axios.create({
   withCredentials: true
 });
 
-// 인스턴스가 생성 된 후 기본값 변경
-instance.defaults.headers.common['Authorization'] = getToken();
+// 요청 인터셉터
+instance.interceptors.request.use(function(request){
+  request.headers['Authorization'] = getToken(); 
+
+  return request;
+})
+
+// 응답 인터셉터
+instance.interceptors.response.use(function (response) {
+
+  const rawToken = response?.headers['Authorization'] as string
+  if(!rawToken) return response;
+
+  setToken(rawToken.split(" ")[1])
+
+  return response;
+
+}, function (error) {
+  // 2xx 외의 범위에 있는 상태 코드는 이 함수를 트리거 합니다.
+  // 응답 오류가 있는 작업 수행
+  return Promise.reject(error);
+});
 
 export default instance;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,7 @@ import RegisterPage from './pages/Register/page';
 import FindPasswordPage from './pages/FindPassword/page';
 import HerbPage from './pages/Herb/page';
 import HerbDetailPage from './pages/HerbDetail/page';
+import Mypage from './pages/Mypage/page';
 
 
 const queryClient = new QueryClient({
@@ -39,6 +40,7 @@ createRoot(document.getElementById('root')!).render(
             <Route index element={<HomePage />} />
             <Route path="herbs" element={<HerbPage />} />
             <Route path="herbs/:herbId" element={<HerbDetailPage />} />
+            <Route path="users/me" element={<Mypage/>}/>
           </Route>
           <Route path='/auth' element={<AuthLayout />}>
             <Route path="login" element={<LoginPage />} />

--- a/src/pages/Home/components/Profile.tsx
+++ b/src/pages/Home/components/Profile.tsx
@@ -22,13 +22,12 @@ export default function Profile() {
 
     function handleDropdown() {
         setIsToggle(prev => !prev)
-        console.log(isToggle)
     }
 
 
 
     return (
-        <div className="flex">
+        <div className="flex relative">
             <img
                 src="https://picsum.photos/800/600"
                 alt="프로필 이미지"

--- a/src/pages/Mypage/components/MypageAnalytics.tsx
+++ b/src/pages/Mypage/components/MypageAnalytics.tsx
@@ -1,0 +1,27 @@
+// interface MypageAnalyticsProps { }
+
+export default function MypageAnalytics() {
+    return (
+        <div className="bg-gray-50 rounded-lg p-6">
+            <h2 className="text-2xl font-semibold text-gray-700 mb-4">활동 통계</h2>
+            <div className="grid grid-cols-4 gap-4">
+                <div className="flex flex-col items-center">
+                    <span className="text-2xl font-bold text-green-700">15</span>
+                    <span className="text-lg text-gray-600">작성 게시글</span>
+                </div>
+                <div className="flex flex-col items-center">
+                    <span className="text-2xl font-bold text-green-700">42</span>
+                    <span className="text-lg text-gray-600">작성 댓글</span>
+                </div>
+                <div className="flex flex-col items-center">
+                    <span className="text-2xl font-bold text-green-700">7</span>
+                    <span className="text-lg text-gray-600">관심 허브</span>
+                </div>
+                <div className="flex flex-col items-center">
+                    <span className="text-2xl font-bold text-green-700">3</span>
+                    <span className="text-lg text-gray-600">재배 중인 허브</span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypageBody.tsx
+++ b/src/pages/Mypage/components/MypageBody.tsx
@@ -1,0 +1,11 @@
+interface MypageBodyProps {
+    children: React.ReactNode
+}
+
+export default function MypageBody({ children }: MypageBodyProps) {
+    return (
+        <div>
+            {children}
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypageContents.tsx
+++ b/src/pages/Mypage/components/MypageContents.tsx
@@ -1,0 +1,32 @@
+// interface MypageContentsProps { }
+
+import { ChangeEvent, MouseEvent, useState } from "react";
+import MypageNavigation from "./MypageNavigation";
+import MypagePost from "./MypagePost";
+
+
+/**TODO: 네비게이션 탭 선택에 따라 글 목록, 댓글 목록, 관심 약초 목록이 렌더링되도록 해야 함  */
+export default function MypageContents() {
+    const [tapIndex, setTapIndex] = useState(0);
+
+    const onClickTaps = (e: MouseEvent<HTMLButtonElement>) => {
+
+        const tapIndex = Number(e.currentTarget.textContent)
+
+        setTapIndex(tapIndex)
+
+    }
+    return (
+        <div>
+
+            {/* 네비게이션 탭 */}
+            <MypageNavigation onClickTaps={onClickTaps} tapIndex={tapIndex} />
+
+            {/* 콘텐츠 */}
+
+            <MypagePost />
+            {/* <MypageComment />
+            <MypageFavoriteHerb /> */}
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypageFooter.tsx
+++ b/src/pages/Mypage/components/MypageFooter.tsx
@@ -1,0 +1,8 @@
+// interface MypageFooterProps { }
+  
+export default function MypageFooter() {
+return (
+  <div>
+ 
+</div>
+)}

--- a/src/pages/Mypage/components/MypageHeader.tsx
+++ b/src/pages/Mypage/components/MypageHeader.tsx
@@ -1,0 +1,6 @@
+
+export default function MypageHeader() {
+    return (
+            <h1 className="text-2xl font-bold text-gray-800 mb-6">마이페이지</h1>
+    )
+}

--- a/src/pages/Mypage/components/MypageNavigation.tsx
+++ b/src/pages/Mypage/components/MypageNavigation.tsx
@@ -1,0 +1,36 @@
+import { MouseEventHandler } from "react";
+
+interface MypageNavigationProps {
+    onClickTaps: MouseEventHandler
+    tapIndex:number
+}
+
+const tabs = [
+    { id: "my-posts", label: "내 게시글", active: true },
+    { id: "my-comments", label: "내 댓글", active: false },
+    { id: "favorite-hub", label: "관심 허브", active: false },
+    { id: "my-garden", label: "내 정원", active: false },
+];
+
+export default function MypageNavigation({ onClickTaps, tapIndex }: MypageNavigationProps) {
+
+
+    return (
+        <div className="border-b border-gray-200">
+            <div className="flex">
+                {tabs.map((tab) => (
+                    <button
+                        key={tab.id}
+                        onClick={onClickTaps}
+                        className={`px-4 py-2 text-lg font-medium ${tab.active
+                            ? "border-b-2 border-green-500 text-green-600"
+                            : "text-gray-500"
+                            }`}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypagePost.tsx
+++ b/src/pages/Mypage/components/MypagePost.tsx
@@ -1,0 +1,57 @@
+// interface MypagePostProps { }
+
+import { Link } from "react-router";
+
+export default function MypagePost() {
+    return (
+        <div className="bg-gray-50 rounded-lg">
+            <div className="border-b border-gray-200 p-4 flex justify-between items-center">
+                <div>
+                    <h3 className="text-lg font-medium text-gray-800">라벤더 재배 팁</h3>
+                    <p className="text-sm text-gray-500">2023-06-01</p>
+                </div>
+                <Link to="" className="text-gray-600 px-2">
+                    <span className="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-1">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                        보기
+                    </span>
+                </Link>
+            </div>
+
+            <div className="border-b border-gray-200 p-4 flex justify-between items-center">
+                <div>
+                    <h3 className="text-lg font-medium text-gray-800">민트 활용법 공유</h3>
+                    <p className="text-sm text-gray-500">2023-05-28</p>
+                </div>
+                <button className="text-gray-600 px-2">
+                    <span className="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-1">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                        보기
+                    </span>
+                </button>
+            </div>
+
+            <div className="p-4 flex justify-between items-center">
+                <div>
+                    <h3 className="text-lg font-medium text-gray-800">로즈마리 효능에 대해</h3>
+                    <p className="text-sm text-gray-500">2023-05-20</p>
+                </div>
+                <button className="text-gray-600 px-2">
+                    <span className="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-1">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                        보기
+                    </span>
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypageProfile.tsx
+++ b/src/pages/Mypage/components/MypageProfile.tsx
@@ -1,0 +1,19 @@
+
+// interface MypageProfileProps { }
+
+import { Link } from "react-router";
+
+export default function MypageProfile() {
+    return (
+        <div className="bg-gray-50 rounded-lg p-6 flex flex-col items-center lg:col-span-1">
+            <h2 className="text-2xl font-semibold text-gray-700 mb-4">프로필</h2>
+            <div className="w-32 h-32 bg-gray-200 rounded-full flex items-center justify-center mb-4">
+                <div className="w-1 h-1 bg-gray-400 rounded-full"></div>
+            </div>
+            <h3 className="text-xl font-semibold text-gray-800 mb-1">허브마스터</h3>
+            <p className="text-blue-500 mb-4">herb@example.com</p>
+            <p className="text-gray-600 text-center mb-4">허브와 약초에 관심이 많은 조보 가드너입니다.</p>
+            <Link to={"/users/me/profile-edit"} className="text-gray-600 border border-gray-300 rounded px-4 py-2 text-sm">프로필 수정</Link>
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypageSettings.tsx
+++ b/src/pages/Mypage/components/MypageSettings.tsx
@@ -1,0 +1,52 @@
+// interface MypageSettingsProps { }
+
+export default function MypageSettings() {
+    return (
+        <div className="bg-gray-50 rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-700 mb-4">설정</h2>
+
+            <div className="space-y-4">
+                <div className="flex items-center justify-between p-2 border-b border-gray-200">
+                    <div className="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-3 text-green-600">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+                        </svg>
+                        <span className="text-gray-700">알림 설정</span>
+                    </div>
+                    <div className="w-12 h-6 flex items-center bg-gray-200 rounded-full p-1 cursor-pointer">
+                        <div className="bg-white w-5 h-5 rounded-full shadow-md transform translate-x-6"></div>
+                    </div>
+                </div>
+
+                <div className="flex items-center justify-between p-2 border-b border-gray-200">
+                    <div className="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-3 text-green-600">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                        </svg>
+                        <span className="text-gray-700">관심 주제 설정</span>
+                    </div>
+                    <div className="text-gray-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                        </svg>
+                    </div>
+                </div>
+
+                <div className="flex items-center justify-between p-2">
+                    <div className="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-3 text-green-600">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                        <span className="text-gray-700">계정 설정</span>
+                    </div>
+                    <div className="text-gray-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/pages/Mypage/components/MypageViewButton.tsx
+++ b/src/pages/Mypage/components/MypageViewButton.tsx
@@ -1,0 +1,11 @@
+import { IoEyeOutline } from "react-icons/io5";
+// interface MypageViewButtonProps { }
+
+export default function MypageViewButton() {
+    return (
+        <div className="flex items-center">
+            <IoEyeOutline />
+            <span className="ml-2">보기</span>
+        </div>
+    )
+}

--- a/src/pages/Mypage/page.tsx
+++ b/src/pages/Mypage/page.tsx
@@ -1,0 +1,35 @@
+import MypageAnalytics from "./components/MypageAnalytics";
+import MypageContents from "./components/MypageContents";
+import MypageHeader from "./components/MypageHeader"
+import MypageProfile from "./components/MypageProfile";
+import MypageSettings from "./components/MypageSettings";
+
+
+export default function Mypage() {
+    return (
+        <div className="bg-white min-h-screen p-6">
+            {/* 마이페이지 헤더 */}
+            <MypageHeader />
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                {/* 프로필 섹션 */}
+                <MypageProfile />
+
+                {/* 활동 통계 및 게시물 섹션 */}
+                <div className="lg:col-span-2 space-y-6">
+                    {/* 활동 통계 */}
+                    <MypageAnalytics />
+
+
+                    {/* 콘텐츠 목록 */}
+                    <MypageContents />
+
+
+                    {/* 설정 섹션 */}
+                    <MypageSettings />
+                </div>
+            </div>
+        </div>
+    );
+};
+

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -2,20 +2,17 @@ import log from "loglevel"
 
 
 export const getToken = () => {
-    let hasToken = null;
-    for (let i = 0; i < 5; i++) {
-        hasToken = localStorage.key(i)?.includes("accessToken")
-    }
-
-    if (!hasToken) {
+    if (localStorage.getItem('accessToken') == null) {
         return
+    } else {
+        const token = localStorage.getItem("accessToken")
+
+        if (!token) {
+            log.warn("빈 값이 반환되었습니다.")
+            return null
+        }
+        return "Bearer " + token
     }
-    const token = localStorage.getItem("accessToken")
-    if (!token) {
-        log.warn("빈 값이 반환되었습니다.")
-        return null
-    }
-    return "Bearer " + token
 }
 
 export const setToken = (value: string) => {


### PR DESCRIPTION
## 📌 PR 제목  
- 마이페이지 초기 디자인 및 레이아웃 작업, axios 인터셉터 추가

## ✨ 변경 사항  
- 마이페이지 초기 레이아웃과 디자인 추가
- accessToken 만료 시 재발급 자동화를 전역적으로 처리하기 위해 axios 인터셉터 추가

## 🔍 테스트 방법  
- 마이페이지
1. npm install -> npm run dev -> '/users/me'(마이페이지) 접속
2. 정상적으로 마이페이지 디자인이 보여지는지 체크, 모바일 상에서 반응형 레이아웃 동작 확인

- axios 
1. accessToken 유효기간이 만료된 후에도 정상적으로 권한 기반 요청이 처리되는지 확인

## ❗ 주의 사항  
- 마이페이지는 초기작업이 된 것이지 완성된 형태가 아니며, 현재 폰트 크기 등이 불일치하여 수정해야 함
- axios 인터셉터 또한 초기 테스트에서는 정상 동작하고 있으나, 추후 동작 유무를 모니터링하여 개선할 예정

## ✅ 관련 이슈  
- 없음 
