### PR TITLE
Feature/mypage: 사용자별 콘텐츠 통계 조회 api 연동

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -41,4 +41,17 @@ export const updateProfileFetch = async (profile: Profile) => {
 }
 
 
-/** 사용자가 작성한 게시글 목록*/
+/** 마이페이지| 유저 통계 */
+export const getUserStatsFetch = async () => {
+    try {
+        const response = await instance.get(
+            apiRoutes.statistics.getAll()
+        )
+        return response.data
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return error.response?.data
+
+        }
+    }
+}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -70,6 +70,9 @@ export const apiRoutes = {
         create: (postId: number, commentId: number) => baseUrl + `/community/posts/${postId}/comments/${commentId || 0}`,
         update: (commentId: number) => baseUrl + `/community/comments/${commentId}`,
         delete: (commentId: number) => baseUrl + `/community/comments/${commentId}`
-    }
+    },
+    statistics: {
+        getAll: () => baseUrl + '/users/me/stats',
+    },
 
 } as const

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -30,7 +30,7 @@ export const queryKeys = {
     },
     // 게시글
     posts: {
-        update:()=>["posts"],
+        update: () => ["posts"],
         getAll: (page: number, size: number, condition: PostSearchCondition) => ["posts", page, size, condition],
         getByPostId: (postId: number) => ["posts", postId],
         getStatistics: (page: number, size: number) => ["posts", "statistics", page, size]
@@ -41,7 +41,11 @@ export const queryKeys = {
     },
     // 댓글
     comments: {
-        getAll: ({ page, size, postId, sortby }: GetCommentFetchParams) => ["comments",postId, page, size, sortby],
+        getAll: ({ page, size, postId, sortby }: GetCommentFetchParams) => ["comments", postId, page, size, sortby],
         update: (postId: number) => ["comments", postId]
-    }
+    },
+    // 통계
+    statistics: {
+        getAll: () => ["comments", "herbBookmark", "posts"],
+    },
 }

--- a/src/hooks/queries/useQueryMypage.ts
+++ b/src/hooks/queries/useQueryMypage.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query"
+import { queryKeys } from "../../config/keys"
+import { getUserStats } from "../../service/user"
+import { UserStats } from "../../types/user.types"
+
+
+
+// 유저 콘텐츠 통계
+export const useUserStatsGetQuery = () => {
+    const { data, isPending, isError, status } = useQuery({
+        queryKey: queryKeys.statistics.getAll(),
+        queryFn: () => getUserStats(),
+
+        retry: 0,
+    })
+
+    const stats: UserStats = data
+    return { stats, isLoading: isPending, isError, status }
+}
+

--- a/src/pages/Home/components/DropdownMenu.tsx
+++ b/src/pages/Home/components/DropdownMenu.tsx
@@ -2,7 +2,12 @@ import { useNavigate } from "react-router"
 import { CiUser } from "react-icons/ci";
 import { IoMdLogOut } from "react-icons/io";
 import { logout } from "../../../service/auth";
-export default function DropdownMenu() {
+
+
+interface DropdownMenuProps {
+    ref: React.RefObject<HTMLDivElement | null>
+}
+export default function DropdownMenu({ ref }: DropdownMenuProps) {
 
     const router = useNavigate();
 
@@ -11,7 +16,7 @@ export default function DropdownMenu() {
     }
 
     return (
-        <div className="absolute w-[115px] h-[75px] border border-[#F2F2F7] rounded-[10px] right-[1.25rem] top-[3.875rem] z-50  bg-white ">
+        <div ref={ref} className="absolute w-[115px] h-[75px] border border-[#F2F2F7] rounded-[10px] right-[1.25rem] top-[3.875rem] z-50  bg-white ">
             <div className="flex flex-col items-start justify-center  h-full rounded-[10px]">
                 <button
                     onClick={() => router("/users/me")}

--- a/src/pages/Home/components/Profile.tsx
+++ b/src/pages/Home/components/Profile.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import {  useRef, useState } from "react"
 import { IoIosArrowDown } from "react-icons/io";
 import { type Profile } from "../../../types/user.types"
 import DropdownMenu from "./DropdownMenu";
@@ -6,6 +6,7 @@ import { useProfileGetQuery } from "../../../hooks/queries/useQueryProfile";
 
 export default function Profile() {
 
+    const dropdownRef = useRef<HTMLDivElement>(null)
     const [isToggle, setIsToggle] = useState(false)
 
 
@@ -16,8 +17,9 @@ export default function Profile() {
         setIsToggle(prev => !prev)
     }
 
+
     return (
-        <div className="flex relative border rounded-2xl py-3 px-2 border-primary-dark-gray bg-[rgba(255,255,255,0.8)]">
+        <div onClick={handleDropdown} className="hover:bg-gray-200 cursor-pointer flex relative border rounded-2xl py-3 px-2 border-primary-dark-gray bg-[rgba(255,255,255,0.8)]">
             <img
                 src={profileInfo.avatarUrl || "https://picsum.photos/800/600"}
                 alt="프로필 이미지"
@@ -26,11 +28,11 @@ export default function Profile() {
                 height={30} />
             <div className="flex ml-2">
                 <p>{profileInfo?.nickname || ''}</p>
-                <button onClick={handleDropdown} className="mx-2 cursor-pointer text-gray-700"><IoIosArrowDown className={`${isToggle ? " rotate-180" : "rotate-0"} transition-transform`} /></button>
+                <button className="mx-2 text-gray-700"><IoIosArrowDown className={`${isToggle ? " rotate-180" : "rotate-0"} transition-transform`} /></button>
             </div>
 
             {
-                isToggle ? <DropdownMenu /> : null
+                isToggle ? <DropdownMenu ref={dropdownRef}/> : null
             }
         </div>
     )

--- a/src/pages/Mypage/components/MypageAnalytics.tsx
+++ b/src/pages/Mypage/components/MypageAnalytics.tsx
@@ -1,29 +1,29 @@
-// interface MypageAnalyticsProps { }
-
+import { useUserStatsGetQuery } from "../../../hooks/queries/useQueryMypage";
 import MypageTitle from "./MypageTitle";
 
 
 
+// TODO: 로딩 스피너 추가해야 함
 export default function MypageAnalytics() {
+
+    const {stats, isLoading, isError, status} = useUserStatsGetQuery();
+
+
     return (
         <div className="bg-gray-50 rounded-lg p-6">
             <MypageTitle text="활동 통계"/>
-            <div className="grid grid-cols-4 gap-4">
+            <div className="grid grid-cols-3 gap-4">
                 <div className="flex flex-col items-center">
-                    <span className="text-[16px] font-bold text-green-700">15</span>
+                    <span className="text-[16px] font-bold text-green-700">{stats.postCount}</span>
                     <span className="text-2xl text-gray-600">작성 게시글</span>
                 </div>
                 <div className="flex flex-col items-center">
-                    <span className="text-[16px] font-bold text-green-700">42</span>
+                    <span className="text-[16px] font-bold text-green-700">{stats.commentCount}</span>
                     <span className="text-2xl text-gray-600">작성 댓글</span>
                 </div>
                 <div className="flex flex-col items-center">
-                    <span className="text-[16px] font-bold text-green-700">7</span>
+                    <span className="text-[16px] font-bold text-green-700">{stats.bookmarkCount}</span>
                     <span className="text-2xl text-gray-600">관심 허브</span>
-                </div>
-                <div className="flex flex-col items-center">
-                    <span className="text-[16px] font-bold text-green-700">3</span>
-                    <span className="text-2xl text-gray-600">재배 중인 허브</span>
                 </div>
             </div>
         </div>

--- a/src/service/user.ts
+++ b/src/service/user.ts
@@ -1,4 +1,4 @@
-import { getProfileFetch, updateProfileFetch } from "../apis/user";
+import { getProfileFetch, getUserStatsFetch, updateProfileFetch } from "../apis/user";
 import { Profile } from "../types/user.types";
 
 
@@ -10,7 +10,15 @@ export const getInitialProfile = async () => {
 }
 
 /** 프로필 수정 요청*/
-export const updateProfile = async (profile:Profile) => {
+export const updateProfile = async (profile: Profile) => {
     const data = await updateProfileFetch(profile);
     return data
+}
+
+
+/** 마이페이지| 유저 통계 */
+export const getUserStats = async () => {
+    const data = await getUserStatsFetch();
+    return data
+
 }

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -12,3 +12,9 @@ export interface Profile extends AvatarUrl {
     nickname: string;
     introduction: string;
 }
+
+export interface UserStats {
+    bookmarkCount:number
+    commentCount:number
+    postCount:number
+}


### PR DESCRIPTION
## 📌 PR 제목  
- 사용자별 콘텐츠 통계 조회 api 연동

## ✨ 변경 사항  
- 사용자별 콘텐츠 통계 조회 api 연동

## 🔍 테스트 방법  
로그인 후 아래와 같이 시도한다.
- 마이페이지 접속 후 해당 유저의 콘텐츠 통계 수치가 렌더링되는지 확인

## ❗ 주의 사항  
- 없음

## ✅ 관련 이슈  
- 없음
